### PR TITLE
Get Method Head Only Option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'jacoco'
     id 'com.eden.orchidPlugin' version "0.21.0"
     id 'com.avast.gradle.docker-compose' version '0.10.11'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
+    id 'org.jetbrains.kotlin.jvm' version '1.4.20'
 }
 
 repositories {
@@ -27,8 +27,8 @@ dependencies {
     implementation 'com.steelbridgelabs.oss:neo4j-gremlin-bolt:0.4.4'
     implementation 'khttp:khttp:1.0.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.3.72'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.20'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.4.20'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.4.0'
     orchidRuntime 'io.github.javaeden.orchid:OrchidDocs:0.21.0'
     orchidRuntime 'io.github.javaeden.orchid:OrchidKotlindoc:0.21.0'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'jacoco'
     id 'com.eden.orchidPlugin' version "0.21.0"
     id 'com.avast.gradle.docker-compose' version '0.10.11'
-    id 'org.jetbrains.kotlin.jvm' version '1.4.20'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.72'
 }
 
 repositories {
@@ -27,8 +27,8 @@ dependencies {
     implementation 'com.steelbridgelabs.oss:neo4j-gremlin-bolt:0.4.4'
     implementation 'khttp:khttp:1.0.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.2'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.20'
-    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.4.20'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.3.72'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.4.0'
     orchidRuntime 'io.github.javaeden.orchid:OrchidDocs:0.21.0'
     orchidRuntime 'io.github.javaeden.orchid:OrchidKotlindoc:0.21.0'

--- a/src/main/kotlin/za/ac/sun/plume/drivers/GremlinDriver.kt
+++ b/src/main/kotlin/za/ac/sun/plume/drivers/GremlinDriver.kt
@@ -217,6 +217,20 @@ abstract class GremlinDriver : IDriver {
         return plumeGraph
     }
 
+    override fun getMethod(fullName: String, signature: String, includeBody: Boolean): PlumeGraph {
+        if (includeBody) return getMethod(fullName, signature)
+        if (!transactionOpen) openTx()
+        val methodSubgraph = g.V().hasLabel(MethodVertex.LABEL.name)
+                .has("fullName", fullName).has("signature", signature)
+                .outE(EdgeLabel.AST.name)
+                .subgraph("sg")
+                .cap<Graph>("sg")
+                .next()
+        val result = gremlinToPlume(methodSubgraph.traversal())
+        if (transactionOpen) closeTx()
+        return result
+    }
+
     override fun getMethod(fullName: String, signature: String): PlumeGraph {
         if (!transactionOpen) openTx()
         val methodSubgraph = g.V().hasLabel(MethodVertex.LABEL.name)

--- a/src/main/kotlin/za/ac/sun/plume/drivers/IDriver.kt
+++ b/src/main/kotlin/za/ac/sun/plume/drivers/IDriver.kt
@@ -81,6 +81,16 @@ interface IDriver : AutoCloseable {
     fun getMethod(fullName: String, signature: String): PlumeGraph
 
     /**
+     * Given the full signature of a method, returns the subgraph of the method body.
+     *
+     * @param fullName The fully qualified name e.g. interprocedural.basic.Basic4.f
+     * @param signature The method signature e.g. int f(int, int)
+     * @param includeBody True if the body should be included, false if only method head should be included.
+     * @return The [PlumeGraph] containing the method graph.
+     */
+    fun getMethod(fullName: String, signature: String, includeBody: Boolean): PlumeGraph
+
+    /**
      * Obtains all program structure related vertices.
      *
      * @return The [PlumeGraph] containing the program structure related sub-graphs.

--- a/src/main/kotlin/za/ac/sun/plume/drivers/TigerGraphDriver.kt
+++ b/src/main/kotlin/za/ac/sun/plume/drivers/TigerGraphDriver.kt
@@ -193,12 +193,24 @@ class TigerGraphDriver : IDriver {
         return graphPayloadToPlumeGraph(result)
     }
 
+    override fun getMethod(fullName: String, signature: String, includeBody: Boolean): PlumeGraph {
+        if (includeBody) return getMethod(fullName, signature)
+        var methodHash = MethodVertex::class.java.hashCode()
+        methodHash = 31 * methodHash + fullName.hashCode()
+        methodHash = 31 * methodHash + signature.hashCode()
+        return getMethod(methodHash, "getMethodHead")
+    }
+
     override fun getMethod(fullName: String, signature: String): PlumeGraph {
         var methodHash = MethodVertex::class.java.hashCode()
         methodHash = 31 * methodHash + fullName.hashCode()
         methodHash = 31 * methodHash + signature.hashCode()
+        return getMethod(methodHash, "getMethod")
+    }
+
+    private fun getMethod(methodHash: Int, path: String): PlumeGraph {
         try {
-            val result = get("query/$GRAPH_NAME/getMethod", mapOf("methodHash" to methodHash.toString()))
+            val result = get("query/$GRAPH_NAME/$path", mapOf("methodHash" to methodHash.toString()))
             return graphPayloadToPlumeGraph(result)
         } catch (e: PlumeTransactionException) {
             logger.warn("${e.message}. This may be a result of the method not being present in the graph.")

--- a/src/test/kotlin/za/ac/sun/plume/drivers/JanusGraphDriverIntTest.kt
+++ b/src/test/kotlin/za/ac/sun/plume/drivers/JanusGraphDriverIntTest.kt
@@ -354,8 +354,32 @@ class JanusGraphDriverIntTest {
         }
 
         @Test
+        fun testGetMethodHeadOnly() {
+            val plumeGraph = driver.getMethod(v1.fullName, v1.signature, false)
+            assertEquals("PlumeGraph(vertices:5, edges:4)", plumeGraph.toString())
+            val graphVertices = plumeGraph.vertices()
+            assertEquals(5, graphVertices.size)
+            // Assert no program structure vertices part of the method body
+            assertFalse(graphVertices.contains(v14))
+            assertFalse(graphVertices.contains(v13))
+            assertFalse(graphVertices.contains(v12))
+            assertFalse(graphVertices.contains(v11))
+            // Check method head
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v2) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v5) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v3) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v10) ?: false)
+            // Check that none of the other vertices exist
+            assertFalse(graphVertices.contains(v4))
+            assertFalse(graphVertices.contains(v6))
+            assertFalse(graphVertices.contains(v7))
+            assertFalse(graphVertices.contains(v8))
+            assertFalse(graphVertices.contains(v9))
+        }
+
+        @Test
         fun testGetMethodBody() {
-            val plumeGraph = driver.getMethod(v1.fullName, v1.signature)
+            val plumeGraph = driver.getMethod(v1.fullName, v1.signature, true)
             assertEquals("PlumeGraph(vertices:9, edges:15)", plumeGraph.toString())
             val graphVertices = plumeGraph.vertices()
             assertEquals(9, graphVertices.size)

--- a/src/test/kotlin/za/ac/sun/plume/drivers/Neo4jDriverIntTest.kt
+++ b/src/test/kotlin/za/ac/sun/plume/drivers/Neo4jDriverIntTest.kt
@@ -364,8 +364,32 @@ class Neo4jDriverIntTest {
         }
 
         @Test
+        fun testGetMethodHeadOnly() {
+            val plumeGraph = driver.getMethod(v1.fullName, v1.signature, false)
+            assertEquals("PlumeGraph(vertices:5, edges:4)", plumeGraph.toString())
+            val graphVertices = plumeGraph.vertices()
+            assertEquals(5, graphVertices.size)
+            // Assert no program structure vertices part of the method body
+            assertFalse(graphVertices.contains(v14))
+            assertFalse(graphVertices.contains(v13))
+            assertFalse(graphVertices.contains(v12))
+            assertFalse(graphVertices.contains(v11))
+            // Check method head
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v2) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v5) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v3) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v10) ?: false)
+            // Check that none of the other vertices exist
+            assertFalse(graphVertices.contains(v4))
+            assertFalse(graphVertices.contains(v6))
+            assertFalse(graphVertices.contains(v7))
+            assertFalse(graphVertices.contains(v8))
+            assertFalse(graphVertices.contains(v9))
+        }
+
+        @Test
         fun testGetMethodBody() {
-            val plumeGraph = driver.getMethod(v1.fullName, v1.signature)
+            val plumeGraph = driver.getMethod(v1.fullName, v1.signature, true)
             assertEquals("PlumeGraph(vertices:9, edges:15)", plumeGraph.toString())
             val graphVertices = plumeGraph.vertices()
             assertEquals(9, graphVertices.size)

--- a/src/test/kotlin/za/ac/sun/plume/drivers/NeptuneDriverIntTest.kt
+++ b/src/test/kotlin/za/ac/sun/plume/drivers/NeptuneDriverIntTest.kt
@@ -357,8 +357,32 @@ class NeptuneDriverIntTest {
         }
 
         @Test
+        fun testGetMethodHeadOnly() {
+            val plumeGraph = driver.getMethod(v1.fullName, v1.signature, false)
+            assertEquals("PlumeGraph(vertices:5, edges:4)", plumeGraph.toString())
+            val graphVertices = plumeGraph.vertices()
+            assertEquals(5, graphVertices.size)
+            // Assert no program structure vertices part of the method body
+            assertFalse(graphVertices.contains(v14))
+            assertFalse(graphVertices.contains(v13))
+            assertFalse(graphVertices.contains(v12))
+            assertFalse(graphVertices.contains(v11))
+            // Check method head
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v2) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v5) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v3) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v10) ?: false)
+            // Check that none of the other vertices exist
+            assertFalse(graphVertices.contains(v4))
+            assertFalse(graphVertices.contains(v6))
+            assertFalse(graphVertices.contains(v7))
+            assertFalse(graphVertices.contains(v8))
+            assertFalse(graphVertices.contains(v9))
+        }
+
+        @Test
         fun testGetMethodBody() {
-            val plumeGraph = driver.getMethod(v1.fullName, v1.signature)
+            val plumeGraph = driver.getMethod(v1.fullName, v1.signature, true)
             assertEquals("PlumeGraph(vertices:9, edges:15)", plumeGraph.toString())
             val graphVertices = plumeGraph.vertices()
             assertEquals(9, graphVertices.size)

--- a/src/test/kotlin/za/ac/sun/plume/drivers/TigerGraphDriverIntTest.kt
+++ b/src/test/kotlin/za/ac/sun/plume/drivers/TigerGraphDriverIntTest.kt
@@ -358,8 +358,32 @@ class TigerGraphDriverIntTest {
         }
 
         @Test
+        fun testGetMethodHeadOnly() {
+            val plumeGraph = driver.getMethod(v1.fullName, v1.signature, false)
+            assertEquals("PlumeGraph(vertices:5, edges:4)", plumeGraph.toString())
+            val graphVertices = plumeGraph.vertices()
+            assertEquals(5, graphVertices.size)
+            // Assert no program structure vertices part of the method body
+            assertFalse(graphVertices.contains(v14))
+            assertFalse(graphVertices.contains(v13))
+            assertFalse(graphVertices.contains(v12))
+            assertFalse(graphVertices.contains(v11))
+            // Check method head
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v2) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v5) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v3) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v10) ?: false)
+            // Check that none of the other vertices exist
+            assertFalse(graphVertices.contains(v4))
+            assertFalse(graphVertices.contains(v6))
+            assertFalse(graphVertices.contains(v7))
+            assertFalse(graphVertices.contains(v8))
+            assertFalse(graphVertices.contains(v9))
+        }
+
+        @Test
         fun testGetMethodBody() {
-            val plumeGraph = driver.getMethod(v1.fullName, v1.signature)
+            val plumeGraph = driver.getMethod(v1.fullName, v1.signature, true)
             assertEquals("PlumeGraph(vertices:9, edges:15)", plumeGraph.toString())
             val graphVertices = plumeGraph.vertices()
             assertEquals(9, graphVertices.size)

--- a/src/test/kotlin/za/ac/sun/plume/drivers/TinkerGraphDriverTest.kt
+++ b/src/test/kotlin/za/ac/sun/plume/drivers/TinkerGraphDriverTest.kt
@@ -421,8 +421,32 @@ class TinkerGraphDriverTest {
         }
 
         @Test
+        fun testGetMethodHeadOnly() {
+            val plumeGraph = driver.getMethod(v1.fullName, v1.signature, false)
+            assertEquals("PlumeGraph(vertices:5, edges:4)", plumeGraph.toString())
+            val graphVertices = plumeGraph.vertices()
+            assertEquals(5, graphVertices.size)
+            // Assert no program structure vertices part of the method body
+            assertFalse(graphVertices.contains(v14))
+            assertFalse(graphVertices.contains(v13))
+            assertFalse(graphVertices.contains(v12))
+            assertFalse(graphVertices.contains(v11))
+            // Check method head
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v2) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v5) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v3) ?: false)
+            assertTrue(plumeGraph.edgesOut(v1)[EdgeLabel.AST]?.contains(v10) ?: false)
+            // Check that none of the other vertices exist
+            assertFalse(graphVertices.contains(v4))
+            assertFalse(graphVertices.contains(v6))
+            assertFalse(graphVertices.contains(v7))
+            assertFalse(graphVertices.contains(v8))
+            assertFalse(graphVertices.contains(v9))
+        }
+
+        @Test
         fun testGetMethodBody() {
-            val plumeGraph = driver.getMethod(v1.fullName, v1.signature)
+            val plumeGraph = driver.getMethod(v1.fullName, v1.signature, true)
             assertEquals("PlumeGraph(vertices:9, edges:15)", plumeGraph.toString())
             val graphVertices = plumeGraph.vertices()
             assertEquals(9, graphVertices.size)

--- a/src/test/resources/schema/tg_schema.gsql
+++ b/src/test/resources/schema/tg_schema.gsql
@@ -69,6 +69,20 @@ CREATE QUERY showAll() FOR GRAPH cpg {
   PRINT @@edges;
 }
 
+CREATE QUERY getMethodHead(VERTEX<CPG_VERT> methodHash) FOR GRAPH cpg {
+  SetAccum<EDGE> @@edges;
+  start = {methodHash};
+  allVert = {methodHash};
+
+  start = SELECT t
+          FROM start:s -(AST:e)-> :t
+          ACCUM @@edges += e;
+  allVert = allVert UNION start;
+
+  PRINT allVert;
+  PRINT @@edges;
+}
+
 CREATE QUERY getMethod(VERTEX<CPG_VERT> methodHash) FOR GRAPH cpg {
   SetAccum<EDGE> @@edges;
   OrAccum @visited;


### PR DESCRIPTION
Created an overloaded version of getMethod which can specify whether the full body of only the head is to be returned.