### PR TITLE
Fixed instance where tags in strings would interfere with parsing

### DIFF
--- a/src/main/kotlin/za/ac/sun/plume/graphio/GraphMLWriter.kt
+++ b/src/main/kotlin/za/ac/sun/plume/graphio/GraphMLWriter.kt
@@ -48,13 +48,13 @@ object GraphMLWriter {
         val keySet = HashMap<String, String>()
         vertices.forEach { v ->
             VertexMapper.vertexToMap(v)
-                    .apply { this.remove("label") }
-                    .forEach { (t, u) ->
-                        when (u) {
-                            is String -> keySet[t] = "string"
-                            is Int -> keySet[t] = "int"
-                        }
+                .apply { this.remove("label") }
+                .forEach { (t, u) ->
+                    when (u) {
+                        is String -> keySet[t] = "string"
+                        is Int -> keySet[t] = "int"
                     }
+                }
         }
         fw.write("<key id=\"labelV\" for=\"node\" attr.name=\"labelV\" attr.type=\"string\"></key>")
         fw.write("<key id=\"labelE\" for=\"edge\" attr.name=\"labelE\" attr.type=\"string\"></key>")
@@ -72,11 +72,13 @@ object GraphMLWriter {
         vertices.forEach { v ->
             fw.write("<node id=\"${v.hashCode()}\">")
             VertexMapper.vertexToMap(v)
-                    .apply { fw.write("<data key=\"labelV\">${this.remove("label")}</data>") }
-                    .forEach { (t, u) -> fw.write("<data key=\"$t\">$u</data>") }
+                .apply { fw.write("<data key=\"labelV\">${this.remove("label")}</data>") }
+                .forEach { (t, u) -> fw.write("<data key=\"$t\">${escape(u)}</data>") }
             fw.write("</node>")
         }
     }
+
+    private fun escape(o: Any) = if (o is String) o.replace("<", "&lt;").replace(">", "&gt;") else o.toString()
 
     private fun writeEdges(fw: OutputStreamWriter, graph: PlumeGraph) {
         val vertices = graph.vertices()

--- a/src/test/kotlin/za/ac/sun/plume/graphio/GraphMLTest.kt
+++ b/src/test/kotlin/za/ac/sun/plume/graphio/GraphMLTest.kt
@@ -27,7 +27,7 @@ class GraphMLTest {
         private val v1 = MethodVertex(STRING_1, STRING_1, STRING_2, STRING_1, INT_1, INT_2, INT_1)
         private val v2 = MethodParameterInVertex(STRING_1, EVAL_1, STRING_1, INT_1, STRING_2, INT_2)
         private val v3 = BlockVertex(STRING_1, STRING_1, STRING_1, INT_1, INT_2, INT_2, INT_1)
-        private val v4 = CallVertex(STRING_1, INT_1, DISPATCH_1, STRING_1, STRING_1, STRING_2, STRING_2, STRING_2, INT_1, INT_1, INT_1)
+        private val v4 = CallVertex("<init>", INT_1, DISPATCH_1, STRING_1, STRING_1, STRING_2, STRING_2, STRING_2, INT_1, INT_1, INT_1)
         private val v5 = LocalVertex(STRING_1, STRING_2, INT_1, INT_1, STRING_1, INT_1)
         private val v6 = IdentifierVertex(STRING_1, STRING_1, STRING_1, INT_1, INT_1, INT_1, INT_1)
         private val v7 = TypeDeclVertex(STRING_1, STRING_2, STRING_1, INT_1)
@@ -46,7 +46,7 @@ class GraphMLTest {
         @JvmStatic
         @AfterAll
         fun tearDownAll() {
-            File(testGraphML).delete()
+//            File(testGraphML).delete()
         }
     }
 


### PR DESCRIPTION
Methods with names containing "<" or ">" would not be escaped and thus interfere with GraphML parsing. This fix addresses that and escapes these chars.