### PR TITLE
Migrating to GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+name: Kotlin CI with Gradle
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: [ 11, 12, 13, 14 ]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        lfs: true
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Compile classes
+      run: ./gradlew classes
+    - name: Run unit tests
+      run: ./gradlew test
+    - name: Run JanusGraph integration tests
+      run: ./gradlew janusGraphIntTest
+    - name: Run TigerGraph integration tests
+      run: ./gradlew tigerGraphIntTest
+    - name: Run Neo4j integration tests
+      run: ./gradlew neo4jIntTest
+    - name: Compile coverage report
+      run: ./gradlew jacocoTestReport
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: ./build/reports/jacoco

--- a/.github/workflows/orchid.yml
+++ b/.github/workflows/orchid.yml
@@ -1,0 +1,21 @@
+name: KDocs with Orchid
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build and deploy Orchid token
+      run: ./gradlew :orchidDeploy -PorchidEnvironment=prod

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Plume
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Build Status](https://travis-ci.org/plume-oss/plume-driver.svg?branch=develop)](https://travis-ci.org/plume-oss/plume-driver)
+![GitHub Actions](https://github.com/plume-oss/plume-driver/workflows/Kotlin%20CI%20with%20Gradle/badge.svg)
 [![codecov](https://codecov.io/gh/plume-oss/plume-driver/branch/develop/graph/badge.svg)](https://codecov.io/gh/plume-oss/plume-driver)
 
 A Kotlin driver for the Plume library to provide an interface for connecting and writing to various graph databases based


### PR DESCRIPTION
Due to TravisCI's new free tier limitations, this repository will now use GitHub actions for CI/CD